### PR TITLE
feat: add DAG1 and DAG2 skeletons

### DIFF
--- a/dags/stock_anomaly_detection.py
+++ b/dags/stock_anomaly_detection.py
@@ -1,0 +1,55 @@
+from airflow.decorators import dag, task
+from airflow.operators.empty import EmptyOperator
+from airflow.utils.dates import datetime
+from datetime import timedelta
+
+# 상위 시가총액 + 테마주 + 업종다양화 추천종목
+TICKERS = [
+        '005930.KS', # 삼성전자 
+        '000660.KS', # SK하이닉스 
+        '373220.KQ', # LG에너지솔루션 
+        '247540.KQ', # 에코프로비엠 
+        '068270.KQ', # 셀트리온 
+        '035720.KQ', # 카카오 
+        '034020.KQ', # 두산에너빌리티 
+        '011200.KS', # HMM 
+        '086790.KQ', # 하나금융지주 
+        '035760.KQ', # CJ ENM
+]
+   
+@dag(
+    dag_id='stock_anomaly_detection',
+    schedule_interval='@daily',
+    start_date=datetime(2024, 5, 1),
+    catchup=True,
+    max_active_runs=1,
+    tags=['stock', 'anomaly']
+)
+
+def stock_anomaly_detection():
+
+    @task
+    def fetch_stock(ticker: str, ds: str):
+        # yfinance 등으로 주가 수집
+        return 
+
+    @task
+    def detect_anomaly(stock_data: dict):
+        # 이상치 판단 로직
+        return 
+
+    @task.branch
+    def choose_branch(ds: str):
+        return "run_pipeline" if ds >= "2024-05-21" else "fetch_only"
+
+    fetch_only = EmptyOperator(task_id="fetch_only")
+    run_pipeline = EmptyOperator(task_id="run_pipeline")
+
+    fetched = fetch_stock.expand(ticker=TICKERS)
+    anomalies = detect_anomaly.expand(stock_data=fetched)
+
+    branch = choose_branch()
+    branch >> [fetch_only, run_pipeline]
+    fetched >> anomalies >> run_pipeline
+
+stock_anomaly_detection()

--- a/dags/stock_news_match_pipeline.py
+++ b/dags/stock_news_match_pipeline.py
@@ -1,0 +1,34 @@
+from airflow.decorators import dag, task
+from airflow.utils.dates import datetime
+
+@dag(
+    dag_id='stock_news_match_pipeline',
+    start_date=datetime(2024, 5, 21),
+    schedule_interval='@daily',
+    catchup=True,
+    max_active_runs=1,
+    tags=['stock', 'news'],
+)
+def stock_news_match_pipeline():
+
+    @task
+    def load_anomalies(ds: str) -> list:
+        """
+        TODO: DAG1에서 저장된 이상치 발생 정보 csv 파일을 읽어 anomaly 리스트 반환
+        리턴 예: [{'ticker': '005930.KS', 'date': '2024-05-21'}, ...]
+        """
+        return []
+
+    @task
+    def fetch_news(anomaly: dict):
+        """
+        TODO: ticker와 날짜(date)를 기준으로 뉴스 수집
+        - date 기준 -3일 ~ 당일 범위로 설정 가능
+        """
+        pass
+
+    anomalies = load_anomalies()
+    fetch_news.expand(anomaly=anomalies)
+
+stock_news_match_pipeline()
+


### PR DESCRIPTION
### 개요
- DAG1 (주가 이상치 탐지)와 DAG2 (뉴스 매칭)의 스켈레톤 코드 추가

### 주요 내용
- `dags/stock_anomaly_detection.py`: 주가 수집 및 이상치 판단 DAG 구조 정의
- `dags/stock_news_match_pipeline.py`: 이상치 날짜 기준 뉴스 수집 DAG 구조 정의

### 향후 계획
- 각 DAG별 세부 기능은 feature 브랜치에서 이어서 개발 예정
- 예: `feature/dag1-stock-fetch`, `feature/dag2-news-match`